### PR TITLE
WIP: bugfix solved in `WaveformSet` computations

### DIFF
--- a/element_array_ephys/ephys_organoids.py
+++ b/element_array_ephys/ephys_organoids.py
@@ -971,7 +971,7 @@ class WaveformSet(dj.Imported):
                 [
                     {
                         **unit,
-                        **channel2electrode_map[int(c)],
+                        **channel2electrode_map[str(c)],
                         "waveform_mean": mean_waveforms[unit["unit"] - 1, :, c_idx],
                     }
                     for c_idx, c in enumerate(we.channel_ids)


### PR DESCRIPTION
This PR fixes the following error and the overall calculations for `ephys.WaveformSet.Waveform` and `ephys.WaveformSet.PeakWaveform`. This bugfix has been tested.
```
key = {'organoid_id': 'O13',
 'experiment_start_time': datetime.datetime(2023, 6, 8, 19, 5),
 'insertion_number': 0,
 'start_time': datetime.datetime(2023, 6, 8, 19, 31),
 'end_time': datetime.datetime(2023, 6, 8, 19, 36),
 'paramset_idx': 0}

Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/datajoint/autopopulate.py", line 315, in _populate1
    make(dict(key), **(make_kwargs or {}))
  File "/opt/conda/lib/python3.9/site-packages/element_array_ephys/ephys_organoids.py", line 953, in make
    peak_chn_idx = list(we.channel_ids).index(
ValueError: 3 is not in list
```