### PR TITLE
fix: deprecation of `datetime.utcnow()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,19 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
  [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.4.0] - 2024-06-25
+
++ Fix - all occurrences of `datetime.utcnow()` to `datetime.now(timezone.utc)` due to deprecation.
+
 ## [0.4.0] - 2024-05-28
 
 + Add - support for SpikeInterface version >= 0.101.0 (updated API)
 + Add - feature for memoization of spike sorting results (prevent duplicated runs)
 
-
 ## [0.3.4] - 2024-03-22
 
 + Add - pytest
 + Update - Ephys schema changed from `ephys_acute` to `ephys_no_curation` in `tutorial.ipynb`
-
 
 ## [0.3.3] - 2024-01-24
 + Update - remove PyPi release from `release.yml` since it will fail after the new `setup.py`

--- a/element_array_ephys/readers/kilosort_triggering.py
+++ b/element_array_ephys/readers/kilosort_triggering.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import scipy.io
@@ -258,7 +258,7 @@ class SGLXKilosortPipeline:
                 + module_output_json
             )
 
-            start_time = datetime.utcnow()
+            start_time = datetime.now(timezone.utc)
             self._update_module_status(
                 {
                     module: {
@@ -270,7 +270,7 @@ class SGLXKilosortPipeline:
             )
             with open(module_logfile, "a") as f:
                 subprocess.check_call(command.split(" "), stdout=f)
-            completion_time = datetime.utcnow()
+            completion_time = datetime.now(timezone.utc)
             self._update_module_status(
                 {
                     module: {
@@ -560,7 +560,7 @@ class OpenEphysKilosortPipeline:
                 module_output_json,
             ]
 
-            start_time = datetime.utcnow()
+            start_time = datetime.now(timezone.utc)
             self._update_module_status(
                 {
                     module: {
@@ -572,7 +572,7 @@ class OpenEphysKilosortPipeline:
             )
             with open(module_logfile, "a") as f:
                 subprocess.check_call(command, stdout=f)
-            completion_time = datetime.utcnow()
+            completion_time = datetime.now(timezone.utc)
             self._update_module_status(
                 {
                     module: {

--- a/element_array_ephys/spike_sorting/ecephys_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/ecephys_spike_sorting.py
@@ -23,7 +23,7 @@ The follow pipeline features three tables:
 import datajoint as dj
 from decimal import Decimal
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from element_interface.utils import find_full_path
 from element_array_ephys.readers import (
@@ -90,7 +90,7 @@ class KilosortPreProcessing(dj.Imported):
 
     def make(self, key):
         """Triggers or imports clustering analysis."""
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         task_mode, output_dir = (ephys.ClusteringTask & key).fetch1(
             "task_mode", "clustering_output_dir"
@@ -159,7 +159,7 @@ class KilosortPreProcessing(dj.Imported):
                 "params": params,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -178,7 +178,7 @@ class KilosortClustering(dj.Imported):
     """
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         output_dir = (ephys.ClusteringTask & key).fetch1("clustering_output_dir")
         kilosort_dir = find_full_path(ephys.get_ephys_root_data_dir(), output_dir)
@@ -224,7 +224,7 @@ class KilosortClustering(dj.Imported):
                 **key,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -244,7 +244,7 @@ class KilosortPostProcessing(dj.Imported):
     """
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         output_dir = (ephys.ClusteringTask & key).fetch1("clustering_output_dir")
         kilosort_dir = find_full_path(ephys.get_ephys_root_data_dir(), output_dir)
@@ -304,7 +304,7 @@ class KilosortPostProcessing(dj.Imported):
                 "modules_status": modules_status,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -312,5 +312,6 @@ class KilosortPostProcessing(dj.Imported):
 
         # all finished, insert this `key` into ephys.Clustering
         ephys.Clustering.insert1(
-            {**key, "clustering_time": datetime.utcnow()}, allow_direct_insert=True
+            {**key, "clustering_time": datetime.now(timezone.utc)},
+            allow_direct_insert=True,
         )

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -2,7 +2,7 @@
 The following DataJoint pipeline implements the sequence of steps in the spike-sorting routine featured in the "spikeinterface" pipeline. Spikeinterface was developed by Alessio Buccino, Samuel Garcia, Cole Hurwitz, Jeremy Magland, and Matthias Hennig (https://github.com/SpikeInterface)
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import datajoint as dj
 import pandas as pd
@@ -72,7 +72,7 @@ class PreProcessing(dj.Imported):
 
     def make(self, key):
         """Triggers or imports clustering analysis."""
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         # Get clustering method and output directory.
         clustering_method, output_dir, params = (
@@ -209,7 +209,7 @@ class PreProcessing(dj.Imported):
                 **key,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -228,7 +228,7 @@ class SIClustering(dj.Imported):
     """
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         # Load recording object.
         clustering_method, output_dir, params = (
@@ -272,7 +272,7 @@ class SIClustering(dj.Imported):
                 **key,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -291,7 +291,7 @@ class PostProcessing(dj.Imported):
     """
 
     def make(self, key):
-        execution_time = datetime.utcnow()
+        execution_time = datetime.now(timezone.utc)
 
         # Load recording & sorting object.
         clustering_method, output_dir, params = (
@@ -368,7 +368,7 @@ class PostProcessing(dj.Imported):
                 **key,
                 "execution_time": execution_time,
                 "execution_duration": (
-                    datetime.utcnow() - execution_time
+                    datetime.now(timezone.utc) - execution_time
                 ).total_seconds()
                 / 3600,
             }
@@ -376,5 +376,6 @@ class PostProcessing(dj.Imported):
 
         # Once finished, insert this `key` into ephys.Clustering
         ephys.Clustering.insert1(
-            {**key, "clustering_time": datetime.utcnow()}, allow_direct_insert=True
+            {**key, "clustering_time": datetime.now(timezone.utc)},
+            allow_direct_insert=True,
         )

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
- [x] Deprecation of `datetime.utcnow()` needs updating to `datetime.now(timezone.utc)` for consistency.
- [x] Update version and CHANGELOG