### PR TITLE
fix: `spikes` object, remove `job_kwargs`, replace `output_folder` and code cleanup

### DIFF
--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -1,9 +1,6 @@
-import gc
 import importlib
 import inspect
 import pathlib
-import re
-from decimal import Decimal
 
 import datajoint as dj
 import numpy as np

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -727,7 +727,14 @@ class CuratedClustering(dj.Imported):
             }
 
             spike_locations = sorting_analyzer.get_extension("spike_locations")
-            spikes_df = pd.DataFrame(spike_locations.spikes)
+            extremum_channel_inds = si.template_tools.get_template_extremum_channel(
+                sorting_analyzer, outputs="index"
+            )
+            spikes_df = pd.DataFrame(
+                sorting_analyzer.sorting.to_spike_vector(
+                    extremum_channel_inds=extremum_channel_inds
+                )
+            )
 
             units = []
             for unit_idx, unit_id in enumerate(si_sorting.unit_ids):

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -254,7 +254,7 @@ class SIClustering(dj.Imported):
             si_sorting: si.sorters.BaseSorter = si.sorters.run_sorter(
                 sorter_name=sorter_name,
                 recording=si_recording,
-                output_folder=sorting_output_dir,
+                folder=sorting_output_dir,
                 remove_existing_folder=True,
                 verbose=True,
                 docker_image=sorter_name not in si.sorters.installed_sorters(),

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -331,7 +331,6 @@ class PostProcessing(dj.Imported):
                 folder=analyzer_output_dir,
                 sparse=True,
                 overwrite=True,
-                **job_kwargs,
             )
 
             # The order of extension computation is drawn from sorting_analyzer.get_computable_extensions()

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -11,7 +11,7 @@ import numpy as np
 import spikeinterface as si
 from element_array_ephys import probe, readers
 from element_interface.utils import find_full_path, memoized_result
-from spikeinterface import exporters, postprocessing, qualitymetrics, sorters
+from spikeinterface import exporters, extractors, sorters
 
 from . import si_preprocessing
 


### PR DESCRIPTION
- [x] Main purpose of this PR: to fix the following error in the `CuratedClustering` step: `"AttributeError: 'ComputeSpikeLocations' object has no attribute 'spikes'"`.
     - [x] Solution: `spikes` object no longer available from `ComputeSpikeLocations` -> refactor logic following the same solution implemented [in this PR](https://github.com/datajoint/element-array-ephys/pull/196) in `element_array_ephys` a month ago.
- [x] `job_kwargs` is removed for sparsity calculation following [this PR](https://github.com/datajoint/element-array-ephys/pull/194)
- [x] Code cleanup
- [x] feat: replace `output_folder` with `folder` when calling `run_sorter` following [this PR](https://github.com/datajoint/element-array-ephys/pull/193)