### PR TITLE
fix: major refactor and update methods in LFP processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 
-## [0.5.2] - 2025-05-21
+## [0.6.0] - 2025-05-31
 
-- Add - Major refactor and update methods in `ephys.LFP` processing  
+- Fix - Major refactor and fix methods in `ephys.LFP`  
 
 ## [0.5.1] - 2025-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+
+## [0.5.2] - 2025-05-21
+
+- Add - Major refactor and update methods in `ephys.LFP` processing  
+
 ## [0.5.1] - 2025-04-23
 
 - Add - `execution_duration` to `LFP` table

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -267,7 +267,7 @@ class LFP(dj.Imported):
             - Fetch the raw data files for the given ephys session.
             - Check for missing files or short trace durations in min
             - Design notch filter to remove powerline noise that contaminates the LFP
-            - Downsample the signal with `decimate` and apply an anti-aliasing FIR filter 
+            - Downsample the signal with `decimate` and apply an anti-aliasing FIR filter
         """
         execution_time = datetime.now(timezone.utc)
 
@@ -322,8 +322,10 @@ class LFP(dj.Imported):
                 powerline_noise_freq = (
                     header["notch_filter_frequency"] or POWERLINE_NOISE_FREQ
                 )  # in Hz
-                
-                downsample_factor = int(np.round(lfp_sampling_rate / TARGET_SAMPLING_RATE))
+
+                downsample_factor = int(
+                    np.round(lfp_sampling_rate / TARGET_SAMPLING_RATE)
+                )
 
                 # Get LFP indices (row index of the LFP matrix to be used)
                 lfp_indices = np.array(electrode_query.fetch("channel_idx"), dtype=int)

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -267,8 +267,7 @@ class LFP(dj.Imported):
             - Fetch the raw data files for the given ephys session.
             - Check for missing files or short trace durations in min
             - Design notch filter to remove powerline noise that contaminates the LFP
-            - Downsample the signal with `decimate` to:
-                - apply an anti-aliasing FIR filter and downsample the signal
+            - Downsample the signal with `decimate` and apply an anti-aliasing FIR filter 
         """
         execution_time = datetime.now(timezone.utc)
 
@@ -323,13 +322,8 @@ class LFP(dj.Imported):
                 powerline_noise_freq = (
                     header["notch_filter_frequency"] or POWERLINE_NOISE_FREQ
                 )  # in Hz
-                downsample_factor = int(lfp_sampling_rate / TARGET_SAMPLING_RATE)
-
-                # Check if the downsampling factor is exact
-                if lfp_sampling_rate % TARGET_SAMPLING_RATE != 0:
-                    raise ValueError(
-                        f"Inexact downsampling factor: {lfp_sampling_rate} Hz -> {TARGET_SAMPLING_RATE} Hz"
-                    )
+                
+                downsample_factor = int(np.round(lfp_sampling_rate / TARGET_SAMPLING_RATE))
 
                 # Get LFP indices (row index of the LFP matrix to be used)
                 lfp_indices = np.array(electrode_query.fetch("channel_idx"), dtype=int)

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -328,7 +328,7 @@ class LFP(dj.Imported):
                 downsample_factor = int(np.round(true_ratio))
 
                 # Check if the ratio is within 1% of an integer (1% tolerance)
-                if abs(true_ratio - downsample_factor) > 0.01:
+                if not np.isclose(true_ratio, downsample_factor, rtol=0.01, atol=1e-8):
                     raise ValueError(
                         f"Downsampling factor {true_ratio} is too far from an integer. Check LFP sampling rates."
                     )

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -323,9 +323,15 @@ class LFP(dj.Imported):
                     header["notch_filter_frequency"] or POWERLINE_NOISE_FREQ
                 )  # in Hz
 
-                downsample_factor = int(
-                    np.round(lfp_sampling_rate / TARGET_SAMPLING_RATE)
-                )
+                # Calculate downsampling factor
+                true_ratio = lfp_sampling_rate / TARGET_SAMPLING_RATE
+                downsample_factor = int(np.round(true_ratio))
+
+                # Check if the ratio is within 1% of an integer (1% tolerance)
+                if abs(true_ratio - downsample_factor) > 0.01:
+                    raise ValueError(
+                        f"Downsampling factor {true_ratio} is too far from an integer. Check LFP sampling rates."
+                    )
 
                 # Get LFP indices (row index of the LFP matrix to be used)
                 lfp_indices = np.array(electrode_query.fetch("channel_idx"), dtype=int)

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -355,11 +355,10 @@ class LFP(dj.Imported):
                     zip(electrode_df["channel_idx"], electrode_df["electrode"])
                 )
 
-                # Get electrode ids
-                electrode_ids = [
-                    channel_to_electrode_map[f'{probe_info["port_id"]}-{int(ch):03d}']
-                    for ch in channels
-                ]
+                channel_to_electrode_map = {
+                    f'{probe_info["port_id"]}-{int(channel):03d}': electrode
+                    for channel, electrode in channel_to_electrode_map.items()
+                }
 
             lfps = data.pop("amplifier_data")[lfp_indices]
             lfp_concat.append(lfps)
@@ -391,7 +390,7 @@ class LFP(dj.Imported):
                     **key,
                     "electrode_config_hash": electrode_df["electrode_config_hash"][0],
                     "probe_type": electrode_df["probe_type"][0],
-                    "electrode": electrode_ids[ch_idx],
+                    "electrode": channel_to_electrode_map[ch_idx],
                     "lfp": lfp,
                 }
             )

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -239,7 +239,7 @@ class LFP(dj.Imported):
         -> master
         -> probe.ElectrodeConfig.Electrode
         ---
-        lfp              : blob@datajoint-blob
+        lfp              : blob@datajoint-blob # uV
         """
 
     @property

--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -268,11 +268,7 @@ class LFP(dj.Imported):
             - Check for missing files or short trace durations in min
             - Design notch filter to remove powerline noise that contaminates the LFP
             - Downsample the signal with `decimate` to:
-                - apply an anti-aliasing FIR filter
-                - reduce sampling rate from original (e.g.,20 kHz) to target (e.g., 2.5 kHz)
-                - This preserves LFP content < Nyquist (1.25 kHz), and reduces data size
-            - Insert the filtered and downsampled LFP traces into the ephys.LFP.Trace table.
-            - Update the ephys.LFP table with the execution duration.
+                - apply an anti-aliasing FIR filter and downsample the signal
         """
         execution_time = datetime.now(timezone.utc)
 

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"


### PR DESCRIPTION
This PR proposes the following method for processing broadband LFP signals:
1. Design and apply a notch filter to remove powerline noise at 60 Hz using `iirnotch` and `filtfilt`.
2. Downsample the signal using `scipy.signal.decimate`, instead of using a manual Butterworth + downsample approach. `Decimate` applies an anti-aliasing FIR filter and reduces the sampling rate to 2.5 kHz. `Decimate` is a more integrated, more compact and efficient (less error-prone) than doing it separately.

In this PR, the `ephys.LFP` table logic is refactored for computing and storing LFP traces with improved correctness, clarity, and performance. Key changes include:
- [x] Efficient and accurate downsampling using `scipy.signal.decimate()` with anti-aliasing FIR filters and zero-phase correction.
- [x] Add 1% tolerance check for downsampling factor to ensure robust LFP decimation handling
- [x] explicit list accumulation for timewise concatenation (`np.hstack` for `full_lfp` and `lfp_concat`)
- [x] Clean structure and documentation including structured inline comments and a docstring for the make() method.

