### PR TITLE
Update: Use Spikeinterface official released versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.6.1] - 2025-06-04
+
+- Fix - Use Spikeinterface official released versions
 
 ## [0.6.0] - 2025-05-31
 

--- a/element_array_ephys/version.py
+++ b/element_array_ephys/version.py
@@ -1,3 +1,3 @@
 """Package metadata."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "openpyxl",
         "plotly",
         "seaborn",
-        "spikeinterface @ git+https://github.com/SpikeInterface/spikeinterface.git",
+        "spikeinterface",
         "scikit-image",
         "nbformat>=4.2.0",
         "pyopenephys>=1.1.6",


### PR DESCRIPTION
This PR updates the dependency to use the latest officially released version of SpikeInterface, replacing the previous dev version. This avoids breaking changes from ongoing development. 