### PR TITLE
feat: 3-part make for LFP

### DIFF
--- a/element_array_ephys/ephys_no_curation.py
+++ b/element_array_ephys/ephys_no_curation.py
@@ -395,9 +395,9 @@ class LFP(dj.Imported):
             lfp = signal.decimate(lfp, downsample_factor, ftype="fir", zero_phase=True)
             all_lfps.append(lfp)
 
-        return all_lfps, electrode_df, channel_to_electrode_map, execution_time
+        return all_lfps, channels, electrode_df, channel_to_electrode_map, execution_time
 
-    def make_insert(self, key, all_lfps, electrode_df, channel_to_electrode_map, execution_time):
+    def make_insert(self, key, all_lfps, channels, electrode_df, channel_to_electrode_map, execution_time):
         self.insert1(
             {
                 **key,


### PR DESCRIPTION
This pull request refactors the `make` method in `element_array_ephys/ephys_no_curation.py` to improve modularity and readability by splitting it into three distinct methods: `make_fetch`, `make_compute`, and `make_insert`. Additionally, it introduces class-level constants for better code organization and replaces hardcoded values with these constants.

### Refactoring for Modularity:
* Split the original `make` method into three separate methods:
  - [`make_fetch`](diffhunk://#diff-357c95aa8069da575eeb27af81e3ca7d71b21b5adf3a2ac9121e6d726551ffc6L254-R265): Handles fetching data and returns relevant information, such as file paths, LFP indices, probe information, and electrode data. [[1]](diffhunk://#diff-357c95aa8069da575eeb27af81e3ca7d71b21b5adf3a2ac9121e6d726551ffc6L254-R265) [[2]](diffhunk://#diff-357c95aa8069da575eeb27af81e3ca7d71b21b5adf3a2ac9121e6d726551ffc6R290-R319)
  - [`make_compute`](diffhunk://#diff-357c95aa8069da575eeb27af81e3ca7d71b21b5adf3a2ac9121e6d726551ffc6R389-R422): Processes the fetched data to compute broadband LFP signals for each electrode, including filtering and downsampling. Returns computed LFP signals and mapping data.
  - [`make_insert`](diffhunk://#diff-357c95aa8069da575eeb27af81e3ca7d71b21b5adf3a2ac9121e6d726551ffc6R389-R422): Inserts computed data and metadata into the database, ensuring separation of concerns.
